### PR TITLE
Update to WebUI v2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,22 +91,44 @@ be found in WebUI's website [here](https://webui.me/#download).
 In addition, you can also enable WebUI's logging via `-d:webuiLog` but that flag
 only works for static compilation.
 
-## Supported Browsers
+## Supported Web Browsers
 
-| OS      | Browser | Status        |
-| ------  | ------  | ------        |
-| Windows | Firefox | ✔️            |
-| Windows | Chrome  | ✔️            |
-| Windows | Edge    | ✔️            |
-| Linux   | Firefox | ✔️            |
-| Linux   | Chrome  | ✔️            |
-| macOS   | Firefox | *coming soon* |
-| macOS   | Chrome  | *coming soon* |
-| macOS   | Safari  | *coming soon* |
+| OS | Browser | Status |
+| ------ | ------ | ------ |
+| Windows | Mozilla Firefox | ✔️ |
+| Windows | Google Chrome | ✔️ |
+| Windows | Microsoft Edge | ✔️ |
+| Windows | Chromium | ✔️ |
+| Windows | Yandex | ✔️ |
+| Windows | Brave | ✔️ |
+| Windows | Vivaldi | ✔️ |
+| Windows | Epic | ✔️ |
+| Windows | Opera | *coming soon* |
+| - | - | - |
+| Linux | Mozilla Firefox | ✔️ |
+| Linux | Google Chrome | ✔️ |
+| Linux | Microsoft Edge | *coming soon* |
+| Linux | Chromium | ✔️ |
+| Linux | Yandex | *coming soon* |
+| Linux | Brave | *coming soon* |
+| Linux | Vivaldi | *coming soon* |
+| Linux | Epic | *coming soon* |
+| Linux | Opera | *coming soon* |
+| - | - | - |
+| macOS | Mozilla Firefox | *coming soon* |
+| macOS | Google Chrome | ✔️ |
+| macOS | Microsoft Edge | *coming soon* |
+| macOS | Chromium | *coming soon* |
+| macOS | Yandex | *coming soon* |
+| macOS | Brave | *coming soon* |
+| macOS | Vivaldi | *coming soon* |
+| macOS | Epic | *coming soon* |
+| macOS | Apple Safari | *coming soon* |
+| macOS | Opera | *coming soon* |
 
 ## License
 
 MIT License. See [LICENSE](LICENSE)
 
-Original WebUI library is licensed under LGPL-2.1. See
+Original WebUI library is licensed under GPLv2.0. See
 [LICENSE](https://github.com/alifcommunity/webui/blob/main/LICENSE).

--- a/examples/call_nim_from_js.nim
+++ b/examples/call_nim_from_js.nim
@@ -70,7 +70,7 @@ proc main =
     let status = e.getBool()
     echo "function_three: ", status # true/false
 
-  window.bind("Four") do (e: Event) -> int:
+  window.bind("Four") do (e: Event) -> int64:
     # JavaScript: const result = webui_fn('Four', 2);
 
     result = e.getInt() * 2
@@ -79,8 +79,7 @@ proc main =
     # result is sent back to Javascript for you
 
   # Show the window
-  if not window.show(html, BrowserChrome):  # Run the window on Chrome
-    window.show(html, BrowserAny)           # If not, run on any other installed web browser
+  window.show(html)
 
   # Wait until all windows get closed
   wait()

--- a/examples/hello_world.nim
+++ b/examples/hello_world.nim
@@ -110,8 +110,7 @@ proc main =
     webui.exit()
 
   # Show the window
-  if not window.show(loginHtml, BrowserChrome):  # Run the window on Chrome
-    window.show(loginHtml, BrowserAny)           # If not, run on any other installed web browser
+  window.show(loginHtml)
 
   # Wait until all windows get closed
   wait()

--- a/examples/hello_world_c.nim
+++ b/examples/hello_world_c.nim
@@ -78,8 +78,7 @@ proc main =
     webui.exit()
 
   # Show the window
-  if not window.show(html, BrowserChrome):  # Run the window on Chrome
-    window.show(html, BrowserAny)           # If not, run on any other installed web browser
+  window.show(html)
 
   # Wait until all windows get closed
   wait()

--- a/webui.nim
+++ b/webui.nim
@@ -2,7 +2,7 @@
   Nim wrapper for [WebUI](https://github.com/alifcommunity/webui)
 
   :Author: Jasmine
-  :WebUI Version: 2.0.7
+  :WebUI Version: 2.1.0
 
   # Get Started
 
@@ -616,8 +616,8 @@ proc data*(e: Event): pointer =
 proc response*(e: Event): pointer =
   e.impl.response
 
-proc getInt*(e: Event): int =
-  int bindings.getInt(e.impl)
+proc getInt*(e: Event): int64 =
+  int64 bindings.getInt(e.impl)
 
 proc getString*(e: Event): string =
   $ bindings.getString(e.impl)
@@ -628,8 +628,8 @@ proc getBool*(e: Event): bool =
 
   e.getString() == "true"
 
-proc returnInt*(e: Event; n: int) = 
-  bindings.returnInt(e.impl, cint n)
+proc returnInt*(e: Event; n: int64) = 
+  bindings.returnInt(e.impl, int64 n)
 
 proc returnString*(e: Event; s: string) =
   bindings.returnString(e.impl, cstring s)
@@ -719,22 +719,12 @@ proc core*(win: Window): WindowCore =
 
 {.push discardable.}
 
-proc show*(win: Window; html: string; browser: Browser = BrowserAny): bool = 
+proc show*(win: Window; content: string): bool = 
   ## Show Window `win`. If the window is already shown, the UI will get 
   ## refreshed in the same window.
+  ## `content` can be a file name, or a static HTML script
 
-  bindings.show(win.impl, cstring html, cuint ord(browser))
-
-proc showCopy*(win: Window; html: string; browser: Browser = BrowserAny): bool = 
-  bindings.showCpy(win.impl, cstring html, cuint ord(browser))
-
-proc refresh*(win: Window; html: string): bool = 
-  ## Refresh the window UI with any new HTML content.
-
-  bindings.refresh(win.impl, cstring html)
-
-proc refreshCopy*(win: Window; html: string): bool = 
-  bindings.refreshCpy(win.impl, cstring html)
+  bindings.show(win.impl, cstring content)
 
 {.pop.}
 
@@ -823,7 +813,7 @@ proc `bind`*(win: Window; element: string; `func`: proc (e: Event): string) =
       e.returnString(res)
   )  
 
-proc `bind`*(win: Window; element: string; `func`: proc (e: Event): int) =
+proc `bind`*(win: Window; element: string; `func`: proc (e: Event): int64) =
   win.bind(
     element, 
     proc (e: Event) =

--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -77,7 +77,7 @@ else:
 {.deadCodeElim: on.}
 
 const
-  WEBUI_VERSION*          = "2.0.7"   ## Version
+  WEBUI_VERSION*          = "2.1.0"   ## Version
   WEBUI_HEADER_SIGNATURE* = 0xFF      ## All packets should start with this 8bit
   WEBUI_HEADER_JS*        = 0xFE      ## Javascript result in frontend
   WEBUI_HEADER_CLICK*     = 0xFD      ## Click event
@@ -168,6 +168,12 @@ type
     edge*: cuint      ## 3
     safari*: cuint    ## 4
     chromium*: cuint  ## 5
+    opera*: cuint     ## 6
+    brave*: cuint     ## 7
+    vivaldi*: cuint   ## 8
+    epic*: cuint      ## 9
+    yandex*: cuint    ## 10
+    current*: cuint   ## x
     custom*: cuint    ## 99
 
   Runtime* {.bycopy.} = object
@@ -220,14 +226,8 @@ proc isAnyWindowRunning*(): bool {.cdecl,
 proc isAppRunning*(): bool {.cdecl, importc: "webui_is_app_running", webui.}
 proc setTimeout*(second: cuint) {.cdecl, importc: "webui_set_timeout", webui.}
 proc newWindow*(): ptr Window {.cdecl, importc: "webui_new_window", webui.}
-proc show*(win: ptr Window; html: cstring; browser: cuint): bool {.cdecl,
+proc show*(win: ptr Window; content: cstring): bool {.cdecl,
     importc: "webui_show", webui.}
-proc showCpy*(win: ptr Window; html: cstring; browser: cuint): bool {.cdecl,
-    importc: "webui_show_cpy", webui.}
-proc refresh*(win: ptr Window; html: cstring): bool {.cdecl,
-    importc: "webui_refresh", webui.}
-proc refreshCpy*(win: ptr Window; html: cstring): bool {.cdecl,
-    importc: "webui_refresh_cpy", webui.}
 proc setIcon*(win: ptr Window; iconS: cstring; typeS: cstring) {.cdecl,
     importc: "webui_set_icon", webui.}
 proc multiAccess*(win: ptr Window; status: bool) {.cdecl,
@@ -249,10 +249,10 @@ proc scriptCleanup*(script: ptr Script) {.cdecl,
     importc: "webui_script_cleanup", webui.}
 proc scriptRuntime*(win: ptr Window; runtime: cuint) {.cdecl,
     importc: "webui_script_runtime", webui.}
-proc getInt*(e: ptr Event): cint {.cdecl, importc: "webui_get_int", webui.}
+proc getInt*(e: ptr Event): int64 {.cdecl, importc: "webui_get_int", webui.}
 proc getString*(e: ptr Event): cstring {.cdecl, importc: "webui_get_string", webui.}
 proc getBool*(e: ptr Event): bool {.cdecl, importc: "webui_get_bool", webui.}
-proc returnInt*(e: ptr Event; n: cint) {.cdecl, importc: "webui_return_int", webui.}
+proc returnInt*(e: ptr Event; n: int64) {.cdecl, importc: "webui_return_int", webui.}
 proc returnString*(e: ptr Event; s: cstring) {.cdecl,
     importc: "webui_return_string", webui.}
 proc returnBool*(e: ptr Event; b: bool) {.cdecl, importc: "webui_return_bool", webui.}


### PR DESCRIPTION
#New Features
* Supporting more web browsers
* Search for web browsers in Windows Reg.
* Using the same show() function for HTML script, files, and refresh content
* Support Chrome on macOS
* The `getInt()` and `returnInt()` are now 64bit integer instead of 32bit

#Breaking code
* Switching from `show(html, browser);` to `show(content);`, and it's used for HTML, files, or reload the window
* Removing `showCopy()`, `refresh()`, `refreshCopy()`