### PR TITLE
Mac Build

### DIFF
--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -1,0 +1,6 @@
+import webui
+
+let window = newWindow()
+window.show("<html>Hello</html>")
+
+wait()

--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -73,6 +73,7 @@ else:
     {.passC: "-I" & currentSourceDir / "webui" / "include".}
 
   {.pragma: webui, discardable.}
+  
   {.compile: "./webui/src/mongoose.c".}
   {.compile: "./webui/src/webui.c".}
 

--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -45,9 +45,6 @@ elif useWebuiDll:
 
   {.pragma: webui, dynlib: webuiDll, discardable.}
 else:
-  {.compile: "./webui/src/mongoose.c".}
-  {.compile: "./webui/src/webui.c".}
-
   # -d:webuiLog
   when defined(webuiLog):
     {.passC: "-DWEBUI_LOG".}
@@ -72,10 +69,13 @@ else:
 
     {.passC: "-I" & currentSourceDir / "webui" / "include".}
 
-  when defined(macos):
+  when defined(macosx):
     {.passC: "-I" & currentSourceDir / "webui" / "include".}
+    {.passC: "-DWEBUI_MAX_PATH=255 -fPIC -m64 -shared".}
 
   {.pragma: webui, discardable.}
+  {.compile: "./webui/src/mongoose.c".}
+  {.compile: "./webui/src/webui.c".}
 
 {.deadCodeElim: on.}
 

--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -71,7 +71,7 @@ else:
 
   when defined(macosx):
     {.passC: "-I" & currentSourceDir / "webui" / "include".}
-    {.passC: "-DWEBUI_MAX_PATH=255 -fPIC -m64 -shared".}
+    {.passC: "-DWEBUI_MAX_PATH=255 -fPIC -m64 -shared -D__APPLE__".}
 
   {.pragma: webui, discardable.}
   {.compile: "./webui/src/mongoose.c".}

--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -71,7 +71,6 @@ else:
 
   when defined(macosx):
     {.passC: "-I" & currentSourceDir / "webui" / "include".}
-    {.passC: "-DWEBUI_MAX_PATH=255 -fPIC -m64 -shared -D__APPLE__".}
 
   {.pragma: webui, discardable.}
   {.compile: "./webui/src/mongoose.c".}


### PR DESCRIPTION
Related to #8 and #7

This doesn't totally fix it, but it gets it to build.

- it's `macosx` not `macos`
- the checkout of webui you were using didn't have [apple support](https://github.com/alifcommunity/webui/blob/main/include/webui.h#L87-L101)
- made sure `passC` comes before the `compile`. Not sure if this is needed, but should be slightly more "correct"

After this, it will build without error, but it still pops up a blank window, which might be related to API changes (see #7)

So, I think we can merge that PR and add these minor changes (maybe only switch to `macosx`) and it should work better, everywhere.
